### PR TITLE
Support for marking row and column headers with custom color and text

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -68,5 +68,6 @@ export default {
     sheetRightClickConfig:{}, //自定义底部sheet页右击菜单
     imageUpdateMethodConfig:{}, //自定义图片同步方式
     useKrosCustomization: false, //自定义图片同步方式
-    spreadsheetFunctionsFF: false
+    spreadsheetFunctionsFF: false,
+    ieuMode: false
 }

--- a/src/config.js
+++ b/src/config.js
@@ -69,5 +69,5 @@ export default {
     imageUpdateMethodConfig:{}, //自定义图片同步方式
     useKrosCustomization: false, //自定义图片同步方式
     spreadsheetFunctionsFF: false,
-    ieuMode: false
+    customHeadersMode: false
 }

--- a/src/core.js
+++ b/src/core.js
@@ -150,7 +150,7 @@ luckysheet.create = function (setting) {
     luckysheetConfigsetting.useKrosCustomization = extendsetting.useKrosCustomization;
     luckysheetConfigsetting.spreadsheetFunctionsFF = extendsetting.spreadsheetFunctionsFF;
 
-    luckysheetConfigsetting.ieuMode = extendsetting.ieuMode;
+    luckysheetConfigsetting.customHeadersMode = extendsetting.customHeadersMode;
 
     if (Store.lang === 'zh') flatpickr.localize(Mandarin.zh);
 
@@ -261,13 +261,13 @@ luckysheet.luckysheetextendData = luckysheetextendData;
 
 luckysheet.locales = locales;
 
-luckysheet.setIeuSpecialRows = (specialRows) => {
-    luckysheetConfigsetting.ieuSpecialRows = specialRows;
+luckysheet.setCustomRowHeaders = (customRowHeaders) => {
+    luckysheetConfigsetting.customRowHeaders = customRowHeaders;
     luckysheetrefreshgrid();
 };
 
-luckysheet.setIeuSpecialColumns = (specialColumns) => {
-    luckysheetConfigsetting.ieuSpecialColumns = specialColumns;
+luckysheet.setCustomColumnHeaders = (customColumnHeaders) => {
+    luckysheetConfigsetting.customColumnHeaders = customColumnHeaders;
     luckysheetrefreshgrid();
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -150,6 +150,8 @@ luckysheet.create = function (setting) {
     luckysheetConfigsetting.useKrosCustomization = extendsetting.useKrosCustomization;
     luckysheetConfigsetting.spreadsheetFunctionsFF = extendsetting.spreadsheetFunctionsFF;
 
+    luckysheetConfigsetting.ieuMode = extendsetting.ieuMode;
+
     if (Store.lang === 'zh') flatpickr.localize(Mandarin.zh);
 
     // Store the currently used plugins for monitoring asynchronous loading
@@ -258,6 +260,16 @@ luckysheet.hideLoadingProgress = hideloading;
 luckysheet.luckysheetextendData = luckysheetextendData;
 
 luckysheet.locales = locales;
+
+luckysheet.setIeuSpecialRows = (specialRows) => {
+    luckysheetConfigsetting.ieuSpecialRows = specialRows;
+    luckysheetrefreshgrid();
+};
+
+luckysheet.setIeuSpecialColumns = (specialColumns) => {
+    luckysheetConfigsetting.ieuSpecialColumns = specialColumns;
+    luckysheetrefreshgrid();
+};
 
 export {
     luckysheet

--- a/src/global/draw.js
+++ b/src/global/draw.js
@@ -97,9 +97,9 @@ function luckysheetDrawgridRowTitle(scrollHeight, drawHeight, offsetTop) {
         }
         else {
             let text = r+1;
-            if (luckysheetConfigsetting.ieuMode && luckysheetConfigsetting.ieuSpecialRows && luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex]) {
-                luckysheetTableContent.fillStyle = luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex][r]?.color ?? "#ffffff";
-                text += luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex][r]?.text ?? '';
+            if (luckysheetConfigsetting.customHeadersMode && luckysheetConfigsetting.customRowHeaders && luckysheetConfigsetting.customRowHeaders[Store.currentSheetIndex]) {
+                luckysheetTableContent.fillStyle = luckysheetConfigsetting.customRowHeaders[Store.currentSheetIndex][r]?.color ?? "#ffffff";
+                text += luckysheetConfigsetting.customRowHeaders[Store.currentSheetIndex][r]?.text ?? '';
             } else {
                 luckysheetTableContent.fillStyle = "#ffffff";
             }
@@ -301,9 +301,9 @@ function luckysheetDrawgridColumnTitle(scrollWidth, drawWidth, offsetLeft) {
         }
         else {
             let text = abc;
-            if (luckysheetConfigsetting.ieuMode && luckysheetConfigsetting.ieuSpecialColumns && luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex]) {
-                luckysheetTableContent.fillStyle = luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex][c]?.color ?? "#ffffff";
-                text += luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex][c]?.text ?? '';
+            if (luckysheetConfigsetting.customHeadersMode && luckysheetConfigsetting.customColumnHeaders && luckysheetConfigsetting.customColumnHeaders[Store.currentSheetIndex]) {
+                luckysheetTableContent.fillStyle = luckysheetConfigsetting.customColumnHeaders[Store.currentSheetIndex][c]?.color ?? "#ffffff";
+                text += luckysheetConfigsetting.customColumnHeaders[Store.currentSheetIndex][c]?.text ?? '';
             } else {
                 luckysheetTableContent.fillStyle = "#ffffff";
             }

--- a/src/global/draw.js
+++ b/src/global/draw.js
@@ -19,6 +19,7 @@ import method from './method';
 import Store from '../store';
 import locale from '../locale/locale';
 import sheetmanage from '../controllers/sheetmanage';
+import luckysheetConfigsetting from '../controllers/luckysheetConfigsetting';
 
 function luckysheetDrawgridRowTitle(scrollHeight, drawHeight, offsetTop) {
     if (scrollHeight == null) {
@@ -95,7 +96,13 @@ function luckysheetDrawgridRowTitle(scrollHeight, drawHeight, offsetTop) {
 
         }
         else {
-            luckysheetTableContent.fillStyle = "#ffffff";
+            let text = r+1;
+            if (luckysheetConfigsetting.ieuMode && luckysheetConfigsetting.ieuSpecialRows && luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex]) {
+                luckysheetTableContent.fillStyle = luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex][r]?.color ?? "#ffffff";
+                text += luckysheetConfigsetting.ieuSpecialRows[Store.currentSheetIndex][r]?.text ?? '';
+            } else {
+                luckysheetTableContent.fillStyle = "#ffffff";
+            }
             luckysheetTableContent.fillRect(
                 0,
                 (start_r + offsetTop + firstOffset) , 
@@ -107,13 +114,13 @@ function luckysheetDrawgridRowTitle(scrollHeight, drawHeight, offsetTop) {
             //行标题栏序列号
             luckysheetTableContent.save();//save scale before draw text
             luckysheetTableContent.scale(Store.zoomRatio,Store.zoomRatio);
-            let textMetrics = getMeasureText(r+1, luckysheetTableContent); 
+            let textMetrics = getMeasureText(text, luckysheetTableContent); 
             //luckysheetTableContent.measureText(r + 1);
 
             let horizonAlignPos = (Store.rowHeaderWidth  - textMetrics.width) / 2;
             let verticalAlignPos = (start_r + (end_r - start_r) / 2 + offsetTop) ;
 
-            luckysheetTableContent.fillText(r + 1, horizonAlignPos/Store.zoomRatio, verticalAlignPos/Store.zoomRatio);
+            luckysheetTableContent.fillText(text, horizonAlignPos/Store.zoomRatio, verticalAlignPos/Store.zoomRatio);
             luckysheetTableContent.restore();//restore scale after draw text
         }
 
@@ -293,7 +300,13 @@ function luckysheetDrawgridColumnTitle(scrollWidth, drawWidth, offsetLeft) {
 
         }
         else {
-            luckysheetTableContent.fillStyle = "#ffffff";
+            let text = abc;
+            if (luckysheetConfigsetting.ieuMode && luckysheetConfigsetting.ieuSpecialColumns && luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex]) {
+                luckysheetTableContent.fillStyle = luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex][c]?.color ?? "#ffffff";
+                text += luckysheetConfigsetting.ieuSpecialColumns[Store.currentSheetIndex][c]?.text ?? '';
+            } else {
+                luckysheetTableContent.fillStyle = "#ffffff";
+            }
             luckysheetTableContent.fillRect(
                 (start_c + offsetLeft - 1) , 
                 0, 
@@ -306,13 +319,13 @@ function luckysheetDrawgridColumnTitle(scrollWidth, drawWidth, offsetLeft) {
             luckysheetTableContent.save();//save scale before draw text
             luckysheetTableContent.scale(Store.zoomRatio,Store.zoomRatio);
             
-            let textMetrics = getMeasureText(abc, luckysheetTableContent);
+            let textMetrics = getMeasureText(text, luckysheetTableContent);
             //luckysheetTableContent.measureText(abc);
 
             let horizonAlignPos = Math.round((start_c + (end_c - start_c) / 2 + offsetLeft)  - textMetrics.width / 2);
             let verticalAlignPos = Math.round(Store.columnHeaderHeight / 2 );
             
-            luckysheetTableContent.fillText(abc, horizonAlignPos/Store.zoomRatio, verticalAlignPos/Store.zoomRatio);
+            luckysheetTableContent.fillText(text, horizonAlignPos/Store.zoomRatio, verticalAlignPos/Store.zoomRatio);
             luckysheetTableContent.restore();//restore scale after draw text
         }
 


### PR DESCRIPTION
This PR introduces support for API methods allowing marking column and row headers with custom color and text.

There are two new exposed methods: `setCustomColumnHeaders` and `setCustomRowHeaders`. Both accept one parameter, an object, where keys are sheet indices. For each of those keys, there is another object, where keys are indices of the columns/rows that should be marked. For each key there is an object containing two properties - `color` (color of the header) and `text` (text to be shown in the header).

Let's say we want to mark headers according to the following screenshot (let's say that the index of the current sheet is 2):
![image](https://github.com/titanDevelopers/Luckysheet/assets/4323927/85f0847a-9b1c-4f47-b244-28e4c52c4cd7)

We'll use the following code (note that in both functions there is a `luckysheetrefreshgrid()` call, so the headers are rendered immediately after calling the function):
```ts
luckysheet.setCustomColumnHeaders({ 2: { 0: { color: 'darkorange', text: ' (J. cena)' }} });
luckysheet.setCustomRowHeaders({ 2: { 0: { color: 'lightgreen', text: ' (Konštrukcia)' }} });
```

There is also a feature flag `customHeadersMode` that needs to be set to `true` to activate the custom headers:
```ts
luckysheet.create({
    container: 'luckysheet',
    customHeadersMode: true
});
```